### PR TITLE
Build v 0.2.3:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,13 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
+    - setuptools
+    - wheel
     - python
   run:
     - python
@@ -34,8 +35,14 @@ test:
 about:
   home: https://github.com/andosa/treeinterpreter
   summary: Package for interpreting scikit-learn's decision tree and random forest predictions.
+  description: |
+    Package for interpreting scikit-learn's decision tree and random forest predictions. 
+    Allows decomposing each prediction into bias and feature contribution components.
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  doc_url: https://github.com/andosa/treeinterpreter/blob/master/README.rst
+  dev_url: https://github.com/andosa/treeinterpreter
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
 Upstream: https://github.com/andosa/treeinterpreter
 CF: https://github.com/conda-forge/treeinterpreter-feedstock
 Jira: [PKG-2595]
  - Very minor changes, the major being noarch removed, so the package is now arch specific.
  - Attempted to add upstream tests but tests use load_boston routine from scikit-learn, which has been deprecated from scikit-learn >1.2. Since it is not used anywhere elseand upstream does not put upper constraint on scikit-learn dependency, I have simply deactivated the upstream tests.

[PKG-2595]: https://anaconda.atlassian.net/browse/PKG-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ